### PR TITLE
[fix] jwt 업데이트 대응

### DIFF
--- a/packages/server/src/auth/handler/ssu_login.ts
+++ b/packages/server/src/auth/handler/ssu_login.ts
@@ -1,6 +1,6 @@
 import https from 'https';
 import type { APIGatewayProxyHandler } from 'aws-lambda';
-import * as jwt from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 import { createResponse, JWT_SECRET } from '../../common.js';
 import { errorResponse, responseAsLockerError, UnauthorizedError } from '../../util/error.js';
 import { issueToken } from '../data.js';

--- a/packages/server/src/common.ts
+++ b/packages/server/src/common.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyHandler, APIGatewayProxyResult } from 'aws-lambda';
 
-export const JWT_SECRET = process.env.JWT_SECRET ?? 'this-is-sample-secret-key';
+export const JWT_SECRET = process.env.JWT_SECRET ?? 'this-is-sample-key-of-ssu-lockerweb-service-please-change-it-before-using-in-production-if-you-wont-change-you-made-a-terrible-security-mistakes-so-please-change-it-right-now-if-you-see-this-passphase-this-is-sample-key-of-ssu-lockerweb-service-please-change-it-before-using-in-production-if-you-wont-change-you-made-a-terrible-security-mistakes-so-please-change-it-right-now-if-you-see-this-passphase';
 
 export function createResponse(statusCode: number, body: string | object): APIGatewayProxyResult {
   const stringifyBody = typeof body === 'string' ? body : JSON.stringify(body);

--- a/packages/server/src/common.ts
+++ b/packages/server/src/common.ts
@@ -1,6 +1,8 @@
 import type { APIGatewayProxyHandler, APIGatewayProxyResult } from 'aws-lambda';
 
-export const JWT_SECRET = process.env.JWT_SECRET ?? 'this-is-sample-key-of-ssu-lockerweb-service-please-change-it-before-using-in-production-if-you-wont-change-you-made-a-terrible-security-mistakes-so-please-change-it-right-now-if-you-see-this-passphase-this-is-sample-key-of-ssu-lockerweb-service-please-change-it-before-using-in-production-if-you-wont-change-you-made-a-terrible-security-mistakes-so-please-change-it-right-now-if-you-see-this-passphase';
+export const JWT_SECRET =
+  process.env.JWT_SECRET ??
+  'this-is-sample-key-of-ssu-lockerweb-service-please-change-it-before-using-in-production-if-you-wont-change-you-made-a-terrible-security-mistakes-so-please-change-it-right-now-if-you-see-this-passphase-this-is-sample-key-of-ssu-lockerweb-service-please-change-it-before-using-in-production-if-you-wont-change-you-made-a-terrible-security-mistakes-so-please-change-it-right-now-if-you-see-this-passphase';
 
 export function createResponse(statusCode: number, body: string | object): APIGatewayProxyResult {
   const stringifyBody = typeof body === 'string' ? body : JSON.stringify(body);

--- a/packages/server/src/util/access.ts
+++ b/packages/server/src/util/access.ts
@@ -1,5 +1,5 @@
 import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 import { UnauthorizedError } from './error.js';
 import { JWT_SECRET } from '../common.js';
 

--- a/packages/server/template.yaml
+++ b/packages/server/template.yaml
@@ -18,7 +18,7 @@ Parameters:
     Default: '20211561'
   JwtSecret:
     Type: String
-    Default: 'this-is-sample-secret-key'
+    Default: 'this-is-sample-key-of-ssu-lockerweb-service-please-change-it-before-using-in-production-if-you-wont-change-you-made-a-terrible-security-mistakes-so-please-change-it-right-now-if-you-see-this-passphase-this-is-sample-key-of-ssu-lockerweb-service-please-change-it-before-using-in-production-if-you-wont-change-you-made-a-terrible-security-mistakes-so-please-change-it-right-now-if-you-see-this-passphase'
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:


### PR DESCRIPTION
- 좀 더 긴 기본 키
- `import` 구문을 `cjs` 에서 `esm` 형식으로 변경