### PR TITLE
[feat] CloudFront invalidation 스크립트

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "concurrently -p \"[{name} / {time}]\" -c \"green,magenta\" -n \"client,server\" \"pnpm run -r --filter=client build \" \"pnpm run -r -filter=server build\"",
     "dev": "concurrently -p \"[{name} / {time}]\" -c \"green,blue,magenta\" -n \"client,server(tsc),server\" \"pnpm run -r --filter=client dev \" \"pnpm run -r --filter=server watch\" \"pnpm run -r -filter=server dev\"",
     "delete": "pnpm run --filter=client delete && pnpm run --filter=server delete",
-    "deploy": "node ./scripts/deploy.js"
+    "deploy": "node ./scripts/deploy.js",
+    "cf-invalidate": "node ./scripts/cf-invalidate.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/cf-invalidate.js
+++ b/scripts/cf-invalidate.js
@@ -1,0 +1,32 @@
+import { exec } from 'child_process';
+
+exec('aws cloudformation describe-stacks --stack-name lockerweb', (err, stdout, stderr) => {
+  if (err) {
+    console.error(`Exception thrown: ${err.message}`);
+    return;
+  }
+  if (stderr) {
+    console.error(`Error occurred: ${stderr}`);
+    return;
+  }
+  const stackObj = JSON.parse(stdout);
+  const cfName = stackObj?.['Stacks']?.[0]?.['Outputs']?.find(
+    (elem) => elem['OutputKey'] === 'CfDistributionId',
+  )?.['OutputValue'];
+  if (!cfName) {
+    console.error('Cannot find cloudfront distribution. Please deploy stack first.');
+    return;
+  }
+  console.log(`Found cloudfront distribution: ${cfName}`);
+  exec(`aws cloudfront create-invalidation --distribution-id ${cfName} --paths '/*'`, (err, stdout, stderr) => {
+    if (err) {
+      console.error(`Exception thrown: ${err.message}`);
+      return;
+    }
+    if (stderr) {
+      console.error(`Error occurred: ${stderr}`);
+      return;
+    }
+    console.log(`${stdout}`);
+  });
+});


### PR DESCRIPTION
- `pnpm cf-invalidate` 를 이용하여 편리하게 배포된 CloudFront distribution의 invalidation을 수행할 수 있습니다.
- invalidation 이 aws 비용에 영향을 주는 면을 고려하여 deploy 시 자동 수행하지 않고 수동으로 수행되도록 했습니다.
- 배포와 함께 CloudFront invalidation을 수행하려면 `pnpm deploy && pnpm cf-invalidate` 명령어로 수행하면 됩니다.

Resolves #320.