### PR TITLE
[fix] 클라이언트 배포 시 base url 값을 변경

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "scripts": {
     "dev": "vite dev --port 5002 --host 0.0.0.0",
-    "build": "vite build",
+    "build": "cross-env VITE_BASE_URL= vite build",
     "package": "svelte-kit package",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
- 배포시엔 클라이언트와 API의 base url이 같으므로 빈 `VITE_BASE_URL` 환경 변수를 삽입